### PR TITLE
Compatibility when defining the global object

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -413,6 +413,6 @@
 
   // Support CommonJS
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = fetch;
+    module.exports = self.fetch;
   }
 })();


### PR DESCRIPTION
In environments where window is not defined, line 416 would result in an error 'fetch is not defined'.
At this stage self.fetch is always defined and can be used.
